### PR TITLE
Added a new method called videoUpdate which enables you to change access...

### DIFF
--- a/libraries/Youtube.php
+++ b/libraries/Youtube.php
@@ -526,6 +526,38 @@ class Youtube
         return false;
     }
 
+
+    /**
+        * Make a video either public or hidden
+        * Uses the yt:accessControl 'list' action with permission 'allowed' or 'denied'
+        * Need to include the media group info in order for data to not be overwritten/reset
+        *
+        * @param string $videoId The video you want to change.
+        * @param string $title The video's title.
+        * @param string $description The video's description.
+        * @param string $keywords The keywords you want to tag the video with
+        * @param string $category The category you want to put the video in
+        * @param string $permission Needs to be either 'allowed' or 'denied'
+        * @param string (optional) $user The user name whose account this video will go to. Defaults to the authenticated user.
+        * @param string (optional) $method Defaults to 'PUT'.
+     **/
+    public function videoUpdate($videoId, $title, $description, $keywords, $category, $permission, $user = 'default', $method = 'PUT')
+    {
+        $uri        = "/feeds/api/users/{$user}/uploads/{$videoId}";
+        $xml        = '<?xml version="1.0"?>';
+        $xml        .= '<entry xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xmlns:yt="http://gdata.youtube.com/schemas/2007">';
+        $xml        .= '<media:group>';
+        $xml        .= '<media:title type="plain">'.$title.'</media:title>';
+        $xml        .= '<media:description type="plain">'.$description.'</media:description>';
+        $xml        .= '<media:category scheme="http://gdata.youtube.com/schemas/2007/categories.cat">'.$category.'</media:category>';
+        $xml        .= '<media:keywords>'.$keywords.'</media:keywords>';
+        $xml        .= '</media:group>';
+        $xml        .= '<yt:accessControl action="list" permission="'.$permission.'"/>';
+        $xml        .= '</entry>';
+        return $this->_data_request($uri, $xml, $method);
+    }
+
+
     /**
      * Writes a file specified by path to the stream specified by the handle.
      * The file is written in chunks specified by the chunk size to decrease


### PR DESCRIPTION
... control settings

I'm specifically using this to make a video either listed ('list' = 'allowed') or unlisted ('list' = 'denied') in YouTube.

Downside of this method is that we need to pass the media:group info through again in order for it not to be overwritten.

Signed-off-by: Jim Pannell jim@sixmedia.net
